### PR TITLE
feat(ci-cd): setup GitHub Actions pipeline for Docker build and push

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,0 +1,46 @@
+name: FastAPI CI/CD with Docker
+
+on:
+  push:
+    branches:
+      - main  # غيّرها للفرع اللي شغال عليه
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run tests
+        run: echo "No tests yet..."
+
+  build-and-push-docker:
+    needs: build-and-test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: ${{ secrets.DOCKER_USERNAME }}/fastapi-app:latest


### PR DESCRIPTION
### Summary
- Added `.github/workflows/ci-cd.yml` to automate build and push of Docker images.
- Configured GitHub Actions to trigger on pushes to the main branch.
- Integrated Docker Hub authentication using repository secrets:
  - DOCKER_USERNAME
  - DOCKER_PASSWORD (Access Token)
- Automated Docker image tagging with `latest`.

### Changes
- Created initial CI/CD workflow with two jobs:
  1. **Build and Test**: Installs dependencies and runs basic checks.


### Notes
- Ensure `DOCKER_USERNAME` and `DOCKER_PASSWORD` secrets are correctly set in repository settings.
- Image will be available on Docker Hub at:
  `docker.io/<DOCKER_USERNAME>/fastapi-app:latest`